### PR TITLE
微修正_20240321 #93

### DIFF
--- a/app/assets/stylesheets/custom_styles.css
+++ b/app/assets/stylesheets/custom_styles.css
@@ -72,3 +72,8 @@
       font-size: 24px;
     }
   }
+
+  .your-link-class {
+  color: black; /* リンクの色を黒に設定 */
+  /* 他のスタイルを追加する場合はここに追加 */
+}

--- a/app/assets/stylesheets/custom_styles.css
+++ b/app/assets/stylesheets/custom_styles.css
@@ -77,3 +77,9 @@
   color: black; /* リンクの色を黒に設定 */
   /* 他のスタイルを追加する場合はここに追加 */
 }
+
+main {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh; /* 画面の高さいっぱいに表示 */
+}

--- a/app/controllers/admin/items_controller.rb
+++ b/app/controllers/admin/items_controller.rb
@@ -11,6 +11,7 @@ class Admin::ItemsController < ApplicationController
 
   def create
     @item = Item.new(item_params)
+    @genres = Genre.all
     if @item.save
      flash[:notice] = "商品を追加しました。"
       redirect_to admin_item_path(@item.id)

--- a/app/controllers/public/cart_items_controller.rb
+++ b/app/controllers/public/cart_items_controller.rb
@@ -16,7 +16,7 @@ def create
   if existing_cart_item
     existing_cart_item.amount += cart_item_params[:amount].to_i
     if existing_cart_item.save
-      redirect_to cart_items_path, notice: 'カート内の商品数量を更新しました。'
+      redirect_to public_cart_items_path, notice: 'カート内の商品数量を更新しました。'
     else
       logger.error existing_cart_item.errors.full_messages.join(', ')
       redirect_to root_path, alert: 'カートの商品数量を更新できませんでした。'

--- a/app/models/genre.rb
+++ b/app/models/genre.rb
@@ -1,3 +1,3 @@
 class Genre < ApplicationRecord
-  validates :name, presence: true
+  validates :name, presence: { message: "を選択してください" }
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -2,10 +2,9 @@ class Item < ApplicationRecord
   has_one_attached :image
   belongs_to :genre
   has_many :cart_items
+  
   validates :price, presence: true
-  validates :genre_id, presence: true
   validates :name, presence: true, length: { maximum: 20 }
   validates :image, presence: true
   validates :introduction, presence: true, length: { maximum: 70 }
-
 end

--- a/app/views/admin/customers/index.html.erb
+++ b/app/views/admin/customers/index.html.erb
@@ -2,11 +2,11 @@
 <div class="col-sm-9 col-md-7 col-lg-5 px-5 px-sm-0 mx-auto align-self-center text-start" style="margin-top: 50px; margin-bottom: 50px;">
 <div class="container">
   <div class="row">
-    
+
     <h3>会員一覧</h3>
-    
+
     <table class= "table table-hover table-inverse">
-      
+
       <thead>
         <tr>
         <th>会員ID</th>
@@ -15,7 +15,7 @@
         <th>ステータス</th>
         </tr>
       </thead>
-      
+
       <tbody>
         <% @customers.each do |customer| %>
         <tr>
@@ -33,6 +33,8 @@
         <% end %>
       </tbody>
       </table>
-      
+      <div class="d-flex justify-content-center" style="margin-top: 50px;">
+      <%= paginate @customers %>
+      </div>
   </div>
 </div>

--- a/app/views/admin/genres/edit.html.erb
+++ b/app/views/admin/genres/edit.html.erb
@@ -3,14 +3,14 @@
     <div class="col-sm-9 col-md-7 col-lg-5 px-0">
       <h3>ジャンル編集</h3>
       <% if @genre.errors.any? %>
-      <div class="alert alert-danger">
-      <%= @genre.errors.count %>件のエラーが発生しました
-      <ul class="mb-0">
-      <% @genre.errors.full_messages.each do |message| %>
-      <li><%= message %></li>
-      <% end %>
-      </ul>
-      </div>
+        <div class="alert alert-danger">
+          <%= @genre.errors.count %>件のエラーが発生しました
+          <ul class="mb-0">
+            <% @genre.errors.full_messages.each do |message| %>
+              <li><%= message.gsub("Genre", "ジャンル").gsub("Price", "価格").gsub("Name", "ジャンル").gsub("Image", "商品画像").gsub("Introduction", "商品説明") %></li>
+            <% end %>
+          </ul>
+        </div>
       <% end %>
 
       <%= form_with url: admin_genre_path, method: :patch, model: @genre do |g| %>

--- a/app/views/admin/genres/index.html.erb
+++ b/app/views/admin/genres/index.html.erb
@@ -8,7 +8,7 @@
           <%= @genre.errors.count %>件のエラーが発生しました
           <ul class="mb-0">
             <% @genre.errors.full_messages.each do |message| %>
-              <li><%= message %></li>
+              <li><%= message.gsub("Genre", "ジャンル").gsub("Price", "価格").gsub("Name", "ジャンル").gsub("Image", "商品画像").gsub("Introduction", "商品説明") %></li>
             <% end %>
           </ul>
         </div>

--- a/app/views/admin/items/_form.html.erb
+++ b/app/views/admin/items/_form.html.erb
@@ -2,12 +2,12 @@
   <div class='row'>
     <div class="col-sm-10 col-md-8 col-lg-6 px-5 px-sm-0 mx-auto">
       <h3 class="text-center"><%= title %></h3>
-      <% if item.errors.any? %>
+      <% if @item.errors.any? %>
         <div class="alert alert-danger">
-          <%= item.errors.count %>件のエラーが発生しました
+          <%= @item.errors.count %>件のエラーが発生しました
           <ul class="mb-0">
             <% @item.errors.full_messages.each do |message| %>
-              <li><%= message %></li>
+              <li><%= message.gsub("Genre", "ジャンル").gsub("Price", "価格").gsub("Name", "商品名").gsub("Image", "商品画像").gsub("Introduction", "商品説明") %></li>
             <% end %>
           </ul>
         </div>
@@ -36,7 +36,7 @@
           <th class="text-end">ジャンル</th>
           <td>
             <div class="form-group">
-              <%= f.select :genre_id, options_for_select((genres || []).map { |genre| [genre.name, genre.id] }, item.genre_id), { prompt: "選択してください" }, class: 'form-control' %>
+              <%= f.select :genre_id, options_for_select((@genres || []).map { |genre| [genre.name, genre.id] }, item.genre_id), { prompt: "選択してください" }, class: 'form-control' %>
             </div>
           </td>
         </tr>

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -1,9 +1,10 @@
-<footer>
-  <div class='container mt-5'>
-  	<div class='row'>
-    	<div class='mx-auto'>
-    		<p>Team Jump</p>
-    	</div>
+<footer style="background-color: #a0522d; color: white;">
+  <div class='container'>
+    <div class='row'>
+      <div class='mx-auto'>
+        <p></p>
+        <p>Team <%= content_tag(:i, "", class: "fa-solid fa-cake-candles") %> Jump</p>
+      </div>
     </div>
   </div>
 </footer>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -3,7 +3,7 @@
   <nav class="navbar navbar-expand-lg navbar-dark" style="background-color: #a0522d;">
     <div class="container">
       <!-- 上部左端に配置 -->
-      <div class="d-lg-flex d-none align-items-center col-lg-2">
+      <div class="d-lg-flex d-none align-items-center col-lg-4">
         <!-- Nagano Cake テキスト -->
         <% if customer_signed_in? %>
           <%= link_to root_path, class: "navbar-brand", style: "margin-right: auto; margin-left: 0;" do %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -24,7 +24,7 @@
 
   <body>
     <%= render 'layouts/header' %>
-    <main>
+    <main style="background-color: #FAEBD7;">
       <% flash.each do |message_type, message| %>
         <div class="flash-message <%= message_type %>"><%= message %></div>
       <% end %>

--- a/app/views/public/homes/about.html.erb
+++ b/app/views/public/homes/about.html.erb
@@ -13,7 +13,7 @@
      <p>また、全国への発送可能ですので<strong>「いつ」</strong>でも<strong>「どこ」</strong>でもご注文いただけます。<br></p>
      <p>ぜひご注文ください。
      <i class="fa-solid fa-snowman"></i>
-     <%= link_to admin_sessions_path, class: "your-link-class" do %>
+     <%= link_to new_admin_session_path, class: "your-link-class" do %>
       <i class="fa-solid fa-heart"></i></p>
      <% end %>
      </div>
@@ -21,8 +21,8 @@
 
 
 
-   <div class="container" style="position: relative; text-align: center;">
-  <%= image_tag 'about.jpg', class: "img-fluid", style: "max-width: 100%; max-height: 100%; object-fit: cover; margin: auto;" %>
-
-          
-    
+    <div class="container" style="position: relative; text-align: center;">
+      <%= image_tag 'about.jpg', class: "img-fluid", style: "max-width: 100%; max-height: 100%; object-fit: cover; margin: auto;" %>
+    </div>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -39,11 +39,9 @@ Rails.application.routes.draw do
     resources :registrations, only: [:new, :create]
     # 修正した部分
     delete 'cart_items', to: 'cart_items#destroy_all'
+    get 'cart_items', to: 'cart_items#index'  # カートアイテムを表示するためのルートを追加
   end
   # Move public/cart_items route definition outside of public namespace
-  resources :cart_items, only: [:index, :update, :destroy, :create] do
-    delete :destroy_all, on: :collection
-  end
 
   namespace :admin do
     resources :order_details, only: [:update]


### PR DESCRIPTION
42行目 get 'cart_items', to: 'cart_items#index' # カートアイテムを表示するためのルートを追加
↑なんか入れなくなったので追加

自分だけかもしれないが管理者側で注文詳細履歴の購入者の名前リンクから飛ぶと他の人の会員詳細に飛ぶ

管理者側の会員詳細から注文履歴一覧が見れない

バリケーションの問題と日本語にするの何とかなるかもです。